### PR TITLE
Rename evaluation start time variable

### DIFF
--- a/src/evaluate/evaluate.py
+++ b/src/evaluate/evaluate.py
@@ -40,7 +40,7 @@ class Evaluator(object):
         # Set evaluation mode
         model.eval()
 
-        start = time.time()
+        start_time = time.time()
 
         # Initialize progress bar
         bar = utils.set_progress_bar(
@@ -77,7 +77,7 @@ class Evaluator(object):
         torch.cuda.synchronize()
 
         print("{} evaluation completed in: {} s".format(
-            split.capitalize(), time.time() - start))
+            split.capitalize(), round(time.time() - start_time, 4)))
 
         average_loss = self.compute_final_scores(
             average_loss, nums)


### PR DESCRIPTION
- Evaluation start time is being re-written in the loop, thus the reported completion time is not correct
- (optionally) Rounding the elapsed time to 4 decimal places